### PR TITLE
Add keywords config and clickable links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Roadmap
 
-TODO: make links in the Task list clickable (specific files, possibly lines?)
+- [x] Make links in the task list clickable by pointing to the source file and line when `repo_url` is configured.
 
 ## Features
 
@@ -15,6 +15,8 @@ TODO: make links in the Task list clickable (specific files, possibly lines?)
 - **Seamless Integration**: Integrates flawlessly into the MkDocs build process, both locally and remotely (e.g., GitHub Pages), without requiring additional configuration.
 - **Automatic Deployment**: Ensures that your task list is always up-to-date and published on your website, provided it is referenced in the `nav` section of your `mkdocs.yml` file.
 - **Zero Configuration**: No extra configuration needed – simply add the plugin to your `mkdocs.yml` file, and you're ready to go.
+- **Configurable Keywords**: Specify which annotations to search for by setting the `keywords` option.
+- **Comment Pattern Exclusions**: Lines beginning with `# KEYWORD` or `% KEYWORD` are ignored so code snippets aren't treated as tasks.
 
 ## Installation
 
@@ -26,22 +28,24 @@ pip install mkdocs-task-collector
 
 ## Configuration
 
-Add the `task_collector` plugin to your `mkdocs.yml` configuration file:
+Below is a minimal `mkdocs.yml` showing how to configure the plugin and include
+the generated file in the navigation:
 
-```
+```yaml
+site_name: Example Docs
+
 plugins:
   - search
   - task-collector:
-      output_file: 'tasks-list.md'
-```
+      output_file: tasks-list.md
+      keywords:
+        - NOTE
+        - TODO
+        - PLACEHOLDER
 
-To ensure the generated task list is part of your documentation navigation, add it to the `nav` section in your `mkdocs.yml` file:
-
-```
 nav:
-
-    Home: index.md
-    Tasks: tasks-list.md
+  - Home: index.md
+  - Tasks: tasks-list.md
 ```
 
 ## Usage

--- a/mkdocs_plugins/task_collector.py
+++ b/mkdocs_plugins/task_collector.py
@@ -3,6 +3,7 @@ import os
 import logging
 from mkdocs.plugins import BasePlugin
 from mkdocs.config import config_options
+from mkdocs.structure.files import File
 
 class TaskCollectorPlugin(BasePlugin):
     """
@@ -12,6 +13,11 @@ class TaskCollectorPlugin(BasePlugin):
 
     config_scheme = (
         ('output_file', config_options.Type(str, default='TaskList.md')),
+        (
+            'keywords',
+            config_options.Type(list, default=['NOTE', 'TODO', 'PLACEHOLDER']),
+        ),
+        ('repo_branch', config_options.Type(str, default='main')),
     )
 
     def __init__(self):
@@ -29,8 +35,12 @@ class TaskCollectorPlugin(BasePlugin):
         Returns:
             The list of files, potentially modified.
         """
-        # Define the regex pattern to capture specific keywords not preceded or followed by a backtick
-        pattern = re.compile(r'(?<!`)\b(NOTE|TODO|PLACEHOLDER)\b(?!`)')
+        # Define the regex pattern based on configured keywords.
+        # Skip matches that are wrapped in backticks or preceded by
+        # comment markers like "% " or "# ".
+        keywords = [re.escape(k) for k in self.config.get('keywords', [])]
+        pattern = re.compile(
+            rf"(?<!`)(?<![%#]\s)\b({'|'.join(keywords)})\b(?!`)")
 
         # Get the output file name and path to avoid processing it
         output_filename = self.config['output_file']
@@ -51,8 +61,17 @@ class TaskCollectorPlugin(BasePlugin):
                     for i, line in enumerate(lines):
                         match = pattern.search(line)
                         if match:
-                            # Capture the entire line and store it under the respective file heading
-                            task = f"+ Line {i+1} - {line.strip()}"
+                            # Build a link to the repository if available
+                            repo_url = config.get('repo_url')
+                            link = None
+                            if repo_url:
+                                branch = self.config.get('repo_branch', 'main')
+                                link = f"{repo_url}/blob/{branch}/{file.src_path}#L{i+1}"
+                            line_text = line.strip()
+                            if link:
+                                task = f"+ Line {i+1} - [{line_text}]({link})"
+                            else:
+                                task = f"+ Line {i+1} - {line_text}"
                             tasks_by_file.setdefault(file.src_path, []).append(task)
                             self.logger.debug(f"Found task in {file.src_path}: {task}")
                 except IOError as e:
@@ -66,11 +85,21 @@ class TaskCollectorPlugin(BasePlugin):
 
         # Write to the output file
         self.write_output_file(output_filepath, content)
+
+        # Ensure the generated file is part of the build
+        if not files.get_file_from_path(output_filename):
+            file_obj = File(
+                output_filename,
+                config['docs_dir'],
+                config['site_dir'],
+                config['use_directory_urls'],
+            )
+            files.append(file_obj)
         return files
 
     def write_output_file(self, output_filepath, content):
         """
-        Write content to the specified file and ensure it's added to the list of site files.
+        Write content to the specified output file if it has changed.
 
         Args:
             output_filepath: The path where the output file should be written.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='mkdocs-task-collector',
-    version='0.1.14',  # Incrementing the version number
+    version='0.1.15',  # Incrementing the version number
     description='A MkDocs plugin to collect TODO, NOTE, and PLACEHOLDER annotations.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_task_collector.py
+++ b/tests/test_task_collector.py
@@ -1,0 +1,88 @@
+import sys
+import types
+import os
+import shutil
+
+# Create minimal stub modules for mkdocs
+mkdocs = types.ModuleType('mkdocs')
+mkdocs.plugins = types.ModuleType('mkdocs.plugins')
+class BasePlugin:
+    config_scheme = ()
+mkdocs.plugins.BasePlugin = BasePlugin
+
+mkdocs.config = types.ModuleType('mkdocs.config')
+class StubType:
+    def __init__(self, *_args, **_kwargs):
+        pass
+config_options = types.SimpleNamespace(Type=StubType)
+mkdocs.config.config_options = config_options
+
+mkdocs.structure = types.ModuleType('mkdocs.structure')
+mkdocs.structure.files = types.ModuleType('mkdocs.structure.files')
+class File:
+    def __init__(self, src_path, docs_dir, site_dir, use_directory_urls):
+        self.src_path = src_path
+        self.abs_src_path = os.path.join(docs_dir, src_path)
+        self.dest_path = src_path
+        self.abs_dest_path = os.path.join(site_dir, src_path)
+        self.url = src_path
+    def __repr__(self):
+        return f"File({self.src_path})"
+mkdocs.structure.files.File = File
+class Files(list):
+    def get_file_from_path(self, path):
+        for f in self:
+            if f.src_path == path:
+                return f
+        return None
+mkdocs.structure.files.Files = Files
+
+sys.modules['mkdocs'] = mkdocs
+sys.modules['mkdocs.plugins'] = mkdocs.plugins
+sys.modules['mkdocs.config'] = mkdocs.config
+sys.modules['mkdocs.config.config_options'] = mkdocs.config
+sys.modules['mkdocs.structure'] = mkdocs.structure
+sys.modules['mkdocs.structure.files'] = mkdocs.structure.files
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from mkdocs_plugins.task_collector import TaskCollectorPlugin
+
+
+def test_collect_tasks(tmp_path):
+    docs_dir = tmp_path / "docs"
+    site_dir = tmp_path / "site"
+    docs_dir.mkdir()
+    site_dir.mkdir()
+
+    (docs_dir / "a.md").write_text("TODO: first\n# TODO ignore\n")
+    (docs_dir / "b.md").write_text("NOTE: second\n% NOTE ignore\n")
+
+    files = Files([
+        File("a.md", str(docs_dir), str(site_dir), True),
+        File("b.md", str(docs_dir), str(site_dir), True),
+    ])
+
+    plugin = TaskCollectorPlugin()
+    plugin.config = {
+        'output_file': 'TaskList.md',
+        'keywords': ['TODO', 'NOTE'],
+        'repo_branch': 'main',
+    }
+
+    config = {
+        'docs_dir': str(docs_dir),
+        'site_dir': str(site_dir),
+        'use_directory_urls': True,
+        'repo_url': 'https://example.com/repo'
+    }
+
+    plugin.on_files(files, config)
+
+    output = docs_dir / 'TaskList.md'
+    assert output.exists()
+    text = output.read_text()
+    assert 'a.md' in text
+    assert 'b.md' in text
+    assert 'ignore' not in text
+
+


### PR DESCRIPTION
## Summary
- allow customizing the keywords to search for
- add repo branch option and generate clickable links when `repo_url` is provided
- ensure the generated task list file is included in the build
- update docs with full `mkdocs.yml` example and mention configurable keywords
- bump version to 0.1.15
- add a basic unit test for the plugin
- ignore keywords prefixed by comment markers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68455debf27883249f7f6fd1afa329af